### PR TITLE
check for a main branch first

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -21,27 +21,7 @@ export const fetchDocs = async () => {
         `${repo.owner}/${repo.repo}`,
     );
 
-    // type guard function for AxiosError
-    // needed for the catch in the try/catch block below 
-    function isAxiosError(error: unknown): error is AxiosError {
-        return (error as AxiosError).isAxiosError !== undefined;
-    }
-      
-    // Check if the repo has a main branch
-    // If not, default tot he master branch
-    let treeSha = "main";
-    try {
-      await octokit.rest.git.getRef({
-        ...repo,
-        ref: "heads/main",
-      });
-    } catch (error) {
-        if (isAxiosError(error) && error.response?.status === 404) {
-            treeSha = "master";
-        } else {
-            throw error as Error;
-        }
-    }
+    const { data: { default_branch } } = await octokit.rest.repos.get({ ...repo });
 
     const { data } = await octokit.rest.git.getTree({
         ...repo,


### PR DESCRIPTION
The substrate-developer-hub repo uses the `main` branch convention, some of our other repos use `master`. It's conceivable that this split will continue in the long term, so we should check for a `main` branch first, as `main` is typically a newer naming convention and if it exists it is most likely the primary branch. If it does not exist, then we use the `master` branch when fetching the markdown docs.